### PR TITLE
wording fix in windows autoruns

### DIFF
--- a/autoruns.go
+++ b/autoruns.go
@@ -1,15 +1,16 @@
 package autoruns
 
 type Autorun struct {
-	Type      string `json:"type"`
-	Location  string `json:"location"`
-	ImagePath string `json:"image_path"`
-	ImageName string `json:"image_name"`
-	Arguments string `json:"arguments"`
-	MD5       string `json:"md5"`
-	SHA1      string `json:"sha1"`
-	SHA256    string `json:"sha256"`
-	Entry     string `json:"entry"`
+	Type         string `json:"type"`
+	Location     string `json:"location"`
+	ImagePath    string `json:"image_path"`
+	ImageName    string `json:"image_name"`
+	Arguments    string `json:"arguments"`
+	MD5          string `json:"md5"`
+	SHA1         string `json:"sha1"`
+	SHA256       string `json:"sha256"`
+	Entry        string `json:"entry"`
+	LaunchString string `json:"launch_string"`
 }
 
 func Autoruns() []*Autorun {

--- a/autoruns.go
+++ b/autoruns.go
@@ -1,14 +1,15 @@
 package autoruns
 
 type Autorun struct {
-	Type		string `json:"type"`
-	Location	string `json:"location"`
-	ImagePath	string `json:"image_path"`
-	ImageName	string `json:"image_name"`
-	Arguments	string `json:"arguments"`
-	MD5 		string `json:"md5"`
-	SHA1		string `json:"sha1"`
-	SHA256		string `json:"sha256"`
+	Type      string `json:"type"`
+	Location  string `json:"location"`
+	ImagePath string `json:"image_path"`
+	ImageName string `json:"image_name"`
+	Arguments string `json:"arguments"`
+	MD5       string `json:"md5"`
+	SHA1      string `json:"sha1"`
+	SHA256    string `json:"sha256"`
+	Entry     string `json:"entry"`
 }
 
 func Autoruns() []*Autorun {

--- a/autoruns_darwin.go
+++ b/autoruns_darwin.go
@@ -1,18 +1,19 @@
 package autoruns
 
 import (
-	"os"
-	"strings"
 	"io/ioutil"
+	"os"
 	"path/filepath"
-	"howett.net/plist"
+	"strings"
+
 	"github.com/botherder/go-files"
+	"howett.net/plist"
 )
 
 type Plist struct {
-	Label string `plist:"Label"`
+	Label            string   `plist:"Label"`
 	ProgramArguments []string `plist:"ProgramArguments"`
-	RunAtLoad bool `plist:"RunAtLoad"`
+	RunAtLoad        bool     `plist:"RunAtLoad"`
 }
 
 func parsePlists(entryType string, folders []string) (records []*Autorun) {
@@ -66,18 +67,22 @@ func parsePlists(entryType string, folders []string) (records []*Autorun) {
 			sha256, _ := files.HashFile(imagePath, "sha256")
 
 			newAutorun := Autorun{
-				Type: entryType,
-				Location: filePath,
-				ImagePath: imagePath,
-				ImageName: filepath.Base(imagePath),
-				Arguments: arguments,
-				MD5: md5,
-				SHA1: sha1,
-				SHA256: sha256,
+				Type:         entryType,
+				Location:     filePath,
+				ImagePath:    imagePath,
+				ImageName:    filepath.Base(imagePath),
+				Arguments:    arguments,
+				MD5:          md5,
+				SHA1:         sha1,
+				SHA256:       sha256,
+				LaunchString: imagePath,
+			}
+			if arguments != "" {
+				newAutorun.LaunchString += " " + arguments
 			}
 
 			// Add new record to list.
-			records = append(records, &newAutorun,)
+			records = append(records, &newAutorun)
 		}
 	}
 

--- a/autoruns_windows.go
+++ b/autoruns_windows.go
@@ -1,14 +1,15 @@
 package autoruns
 
 import (
-	"os"
 	"fmt"
-	"strings"
 	"io/ioutil"
+	"os"
 	"path/filepath"
-	"golang.org/x/sys/windows/registry"
-	"github.com/mattn/go-shellwords"
+	"strings"
+
 	"github.com/botherder/go-files"
+	"github.com/mattn/go-shellwords"
+	"golang.org/x/sys/windows/registry"
 )
 
 // Just return a string value for a given registry root Key.
@@ -64,14 +65,14 @@ func stringToAutorun(entryType string, entryLocation string, entryValue string, 
 	sha256, _ := files.HashFile(imagePath, "sha256")
 
 	newAutorun := Autorun{
-		Type: entryType,
-		Location: entryLocation,
+		Type:      entryType,
+		Location:  entryLocation,
 		ImagePath: imagePath,
 		ImageName: filepath.Base(imagePath),
 		Arguments: argsString,
-		MD5: md5,
-		SHA1: sha1,
-		SHA256: sha256,
+		MD5:       md5,
+		SHA1:      sha1,
+		SHA256:    sha256,
 	}
 
 	return &newAutorun
@@ -127,10 +128,10 @@ func windowsGetCurrentVersionRun() (records []*Autorun) {
 				imageLocation := fmt.Sprintf("%s\\%s", registryToString(reg), keyName)
 
 				// We pass the value string to a function to return an Autorun.
-				newAutorun := stringToAutorun("run_key", imageLocation,  value, true)
+				newAutorun := stringToAutorun("run_key", imageLocation, value, true)
 
 				// Add the new autorun to the records.
-				records = append(records, newAutorun,)
+				records = append(records, newAutorun)
 			}
 		}
 	}
@@ -176,7 +177,7 @@ func windowsGetServices() (records []*Autorun) {
 		newAutorun := stringToAutorun("service", imageLocation, imagePath, true)
 
 		// Add the new autorun to the records.
-		records = append(records, newAutorun,)
+		records = append(records, newAutorun)
 	}
 
 	return
@@ -207,7 +208,7 @@ func windowsGetStartupFiles() (records []*Autorun) {
 		// Loop through all files in folder.
 		for _, fileEntry := range filesList {
 			// We skip desktop.ini files.
-			if file.Name() == "desktop.ini" {
+			if fileEntry.Name() == "desktop.ini" {
 				continue
 			}
 
@@ -217,7 +218,7 @@ func windowsGetStartupFiles() (records []*Autorun) {
 			newAutorun := stringToAutorun("startup", startupPath, filePath, false)
 
 			// Add new record to list.
-			records = append(records, newAutorun,)
+			records = append(records, newAutorun)
 		}
 	}
 

--- a/autoruns_windows.go
+++ b/autoruns_windows.go
@@ -42,7 +42,7 @@ func parsePath(entryValue string) ([]string, error) {
 	return args, nil
 }
 
-func stringToAutorun(entryType string, entryLocation string, entryValue string, toParse bool) *Autorun {
+func stringToAutorun(entryType string, entryLocation string, entryValue string, toParse bool, entry string) *Autorun {
 	var imagePath = entryValue
 	var argsString = ""
 
@@ -73,6 +73,7 @@ func stringToAutorun(entryType string, entryLocation string, entryValue string, 
 		MD5:       md5,
 		SHA1:      sha1,
 		SHA256:    sha256,
+		Entry:     entry,
 	}
 
 	return &newAutorun
@@ -128,7 +129,7 @@ func windowsGetCurrentVersionRun() (records []*Autorun) {
 				imageLocation := fmt.Sprintf("%s\\%s", registryToString(reg), keyName)
 
 				// We pass the value string to a function to return an Autorun.
-				newAutorun := stringToAutorun("run_key", imageLocation, value, true)
+				newAutorun := stringToAutorun("run_key", imageLocation, value, true, name)
 
 				// Add the new autorun to the records.
 				records = append(records, newAutorun)
@@ -174,7 +175,7 @@ func windowsGetServices() (records []*Autorun) {
 		imageLocation := fmt.Sprintf("%s\\%s", registryToString(reg), subkeyPath)
 
 		// We pass the value string to a function to return an Autorun.
-		newAutorun := stringToAutorun("service", imageLocation, imagePath, true)
+		newAutorun := stringToAutorun("service", imageLocation, imagePath, true, "")
 
 		// Add the new autorun to the records.
 		records = append(records, newAutorun)
@@ -215,7 +216,7 @@ func windowsGetStartupFiles() (records []*Autorun) {
 			filePath := filepath.Join(startupPath, fileEntry.Name())
 
 			// Instantiate new autorun record.
-			newAutorun := stringToAutorun("startup", startupPath, filePath, false)
+			newAutorun := stringToAutorun("startup", startupPath, filePath, false, "")
 
 			// Add new record to list.
 			records = append(records, newAutorun)

--- a/autoruns_windows.go
+++ b/autoruns_windows.go
@@ -68,6 +68,7 @@ func parsePath(entryValue string) ([]string, error) {
 
 func stringToAutorun(entryType string, entryLocation string, entryValue string, toParse bool, entry string) *Autorun {
 	var imagePath = entryValue
+	var launchString = entryValue
 	var argsString = ""
 
 	// TODO: This optional parsing is quite spaghetti. To change.
@@ -89,15 +90,16 @@ func stringToAutorun(entryType string, entryLocation string, entryValue string, 
 	sha256, _ := files.HashFile(imagePath, "sha256")
 
 	newAutorun := Autorun{
-		Type:      entryType,
-		Location:  entryLocation,
-		ImagePath: imagePath,
-		ImageName: filepath.Base(imagePath),
-		Arguments: argsString,
-		MD5:       md5,
-		SHA1:      sha1,
-		SHA256:    sha256,
-		Entry:     entry,
+		Type:         entryType,
+		Location:     entryLocation,
+		ImagePath:    imagePath,
+		ImageName:    filepath.Base(imagePath),
+		Arguments:    argsString,
+		MD5:          md5,
+		SHA1:         sha1,
+		SHA256:       sha256,
+		Entry:        entry,
+		LaunchString: launchString,
 	}
 
 	return &newAutorun


### PR DESCRIPTION
in the last `for` loop, you used `file` instead of `fileEntry`. I was not able to compile your package without fixing this bug. 

I recommend to use `gofmt` for your code. As you can see, the code looks much prettier with formatted go.